### PR TITLE
Nav scroll transparency

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -7,6 +7,7 @@ nav {
   font-family: adelle-sans, sans-serif;
   font-weight: 400;
   font-style: normal;
+  transition: background-color .5s;
 }
 
 .navbar {

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -92,3 +92,13 @@ a.dropdown-divider {
   padding-right: 49.5%;
   text-decoration: none;
 }
+
+.nav-scrolled {
+    background-color: black !important;
+}
+
+
+
+
+
+

--- a/app/javascript/components/navbar.js
+++ b/app/javascript/components/navbar.js
@@ -5,4 +5,22 @@ const navChange = () => {
     elements_array.forEach(element => element.style.backgroundColor = "transparent");
   };
 };
-export { navChange };
+
+
+const checkScroll = () => {
+  if ( (window.location.pathname === "/") || (window.location.pathname === "/#") ) {
+    const myNav = document.getElementsByTagName("nav");
+    const myNav_array = Array.from(myNav);
+    window.onscroll = function () {
+      "use strict";
+      if (document.body.scrollTop >= 1 || document.documentElement.scrollTop >= 200) {
+          myNav_array[0].classList.add("nav-scrolled");
+      }
+      else {
+        myNav_array[0].classList.remove("nav-scrolled");
+      }
+    };
+  };
+};
+
+export { navChange, checkScroll };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,6 +21,7 @@ require("trix")
 require("@rails/actiontext")
 
 // Internal imports:
+import { checkScroll } from '../components/navbar';
 import { navChange } from '../components/navbar';
 import { initLectureSorting } from '../components/tray';
 
@@ -28,6 +29,7 @@ import { initLectureSorting } from '../components/tray';
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   // initSelect2();
+  checkScroll();
   navChange();
   initLectureSorting();
 });


### PR DESCRIPTION
Added a javascript function that changes the background-color of the navbar upon scroll in only two cases:
1. If the user is on the homepage.
2. If the user is on the homepage and clicks a dummy link appending "#" to the homepage address.

![Screenshot 2020-11-26 at 19 04 57](https://user-images.githubusercontent.com/69588585/100385725-67e14980-301b-11eb-9392-fbfbf09d6fe5.png)
![Screenshot 2020-11-26 at 19 05 08](https://user-images.githubusercontent.com/69588585/100385737-6fa0ee00-301b-11eb-9810-20ed6b04e771.png)

I have also added a crude css transition. We can change the colour as we like.
