### PR TITLE
Turbolinks load issue

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -32,7 +32,7 @@ document.addEventListener('turbolinks:load', () => {
   // initSelect2();
   checkScroll();
   navChange();
-  TextScramble();
   initLectureSorting();
+  TextScramble();
 });
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar sticky-top">
-  <%= link_to root_path, class: "navbar-brand" do %>
+  <%= link_to root_path, method: :get, class: "navbar-brand" do %>
     <%= image_tag "logo200x200.png" %>
   <% end  %>
   <ul class="primary-nav">


### PR DESCRIPTION
1. Added some code to the link_to helper on the brand button that fully loads the root_path.
2. Resolved a javascript conflict by reordering the sequence in which the javascript functions are executed. This will allow all functions to work properly.