### PR TITLE
style changes on selection

### DIFF
--- a/app/assets/stylesheets/components/_tray.scss
+++ b/app/assets/stylesheets/components/_tray.scss
@@ -7,3 +7,8 @@
     color: #333;
   }
 }
+
+.lecture-card.active {
+  background-color: yellow;
+
+}

--- a/app/javascript/components/tray.js
+++ b/app/javascript/components/tray.js
@@ -42,4 +42,4 @@ const initLectureSorting = () => {
   });
 };
 
-export { initLectureSorting, trayItemChange };
+export { initLectureSorting };

--- a/app/javascript/components/tray.js
+++ b/app/javascript/components/tray.js
@@ -3,19 +3,19 @@ import Rails from "@rails/ujs";
 
 // Changing style of lecture#show tray on selection of lecture
 
-const trayItemChange = () => {
-  const trayItem = document.querySelectorAll(".lecture-card");
-  trayItem.forEach(item => {
-    const trayLink = item.children[0].getAttribute('href');
-    console.log(trayLink)
-    console.log(window.location.pathname)
-    if (trayLink === window.location.pathname) {
-      console.log("change!")
-      item.style.backgroundColor = "yellow"
-    } else {
-    };
-  });
-};
+// const trayItemChange = () => {
+//   const trayItem = document.querySelectorAll(".lecture-card");
+//   trayItem.forEach(item => {
+//     const trayLink = item.children[0].getAttribute('href');
+//     console.log(trayLink)
+//     console.log(window.location.pathname)
+//     if (trayLink === window.location.pathname) {
+//       console.log("change!")
+//       item.style.backgroundColor = "yellow"
+//     } else {
+//     };
+//   });
+// };
 
 // Setting drag and drop for lecture cards
 const initLectureSorting = () => {

--- a/app/javascript/components/tray.js
+++ b/app/javascript/components/tray.js
@@ -1,6 +1,22 @@
 import Sortable from "sortablejs";
 import Rails from "@rails/ujs";
 
+// Changing style of lecture#show tray on selection of lecture
+
+const trayItemChange = () => {
+  const trayItem = document.querySelectorAll(".lecture-card");
+  trayItem.forEach(item => {
+    const trayLink = item.children[0].getAttribute('href');
+    console.log(trayLink)
+    console.log(window.location.pathname)
+    if (trayLink === window.location.pathname) {
+      console.log("change!")
+      item.style.backgroundColor = "yellow"
+    } else {
+    };
+  });
+};
+
 // Setting drag and drop for lecture cards
 const initLectureSorting = () => {
   console.log("loaded initLectureSorting");
@@ -26,4 +42,4 @@ const initLectureSorting = () => {
   });
 };
 
-export { initLectureSorting };
+export { initLectureSorting, trayItemChange };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -25,7 +25,7 @@ import { checkScroll } from '../components/navbar';
 import { navChange } from '../components/navbar';
 import { smoothScroll } from '../components/navbar';
 import { initLectureSorting } from '../components/tray';
-import { trayItemChange } from '../components/tray';
+// import { trayItemChange } from '../components/tray';
 import { TextScramble } from '../components/banner';
 import { descriptionTrigger } from '../components/home';
 
@@ -36,7 +36,7 @@ document.addEventListener('turbolinks:load', () => {
   checkScroll();
   smoothScroll();
   navChange();
-  trayItemChange();
+  // trayItemChange();
   descriptionTrigger();
   initLectureSorting();
   TextScramble();

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -25,6 +25,7 @@ import { checkScroll } from '../components/navbar';
 import { navChange } from '../components/navbar';
 import { smoothScroll } from '../components/navbar';
 import { initLectureSorting } from '../components/tray';
+import { trayItemChange } from '../components/tray';
 import { TextScramble } from '../components/banner';
 import { descriptionTrigger } from '../components/home';
 
@@ -35,6 +36,7 @@ document.addEventListener('turbolinks:load', () => {
   checkScroll();
   smoothScroll();
   navChange();
+  trayItemChange();
   descriptionTrigger();
   initLectureSorting();
   TextScramble();

--- a/app/views/shared/_tray.html.erb
+++ b/app/views/shared/_tray.html.erb
@@ -4,11 +4,15 @@
   <div id="lecture-tray" class="d-flex flex-column w-25 tray">
 <% end %>
     <% @course.lectures.order(position: :asc).each do |curriculum_item| %>
-      <%= link_to course_lecture_path(@course, curriculum_item), data_id: curriculum_item.id do %> 
-      <div class="lecture-card rounded shadow p-3 m-3"> 
+      <%= link_to course_lecture_path(@course, curriculum_item), data_id: curriculum_item.id do %>
+        <% if @lecture.id == curriculum_item.id %>
+          <div class="lecture-card rounded active shadow p-3 m-3">
+        <% else %>
+          <div class="lecture-card rounded shadow p-3 m-3">
+        <% end %>
         <% if current_user.is_creator %>
           <span class="drag-icons"><i class="fas fa-ellipsis-v"></i><i class="fas fa-ellipsis-v"></i></span> <%= curriculum_item.title %>
-          <%= link_to course_lecture_path(@course, curriculum_item), method: :delete, data: { confirm: "Are you sure?" } do  %> 
+          <%= link_to course_lecture_path(@course, curriculum_item), method: :delete, data: { confirm: "Are you sure?" } do  %>
             <i class="fas fa-trash"></i>
           <% end %>
         <% else %>


### PR DESCRIPTION
Added a javascript function that changes the style of a tray item on navigation to the appropriate lecture#show page by matching the href in associated with the a tag in the lecture tray item with the url suffix in the browser.

The tray item highlighted:
![Screenshot 2020-11-30 at 13 37 32](https://user-images.githubusercontent.com/69588585/100616900-aaec3700-3311-11eb-8465-643849606fc7.png)
URL suffix navigated to:
![Screenshot 2020-11-30 at 13 37 37](https://user-images.githubusercontent.com/69588585/100616926-b2134500-3311-11eb-913c-5c986677ba9c.png)

Currently the tray is highlighted yellow for testing and display purposes, but any style variable/selection of variables can be manipulated by editing the javascript function.