### PR TITLE
fix to stop the css crashing

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,10 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
     <script src="https://rawgit.com/enyo/dropzone/master/dist/dropzone.js"></script>
     <link rel="stylesheet" href="https://rawgit.com/enyo/dropzone/master/dist/dropzone.css">
-    <%= stylesheet_link_tag params[:controller] %>
+    <% begin %>
+      <%= stylesheet_link_tag params[:controller] %>
+    <% rescue %>
+    <% end %>
     <script>
       Dropzone.options.submissionUpload = {
       paramName: "file", // The name that will be used to transfer the file


### PR DESCRIPTION
in the rails admin commit, I did something in `application.html.erb` to make the stylesheet for error pages only load for actions in the errors controller. the code was too general, and this fixes a bug that arises from application.html.erb not being able to find the css files for other controllers.