### PR TITLE
Courses#show for a given course now redirects to lectures#show

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -12,6 +12,8 @@ class CoursesController < ApplicationController
     if cannot? :read, @course
       flash[:alert] = "You are not enrolled in that course."
       redirect_to courses_path
+    else
+      redirect_to course_lecture_path(@course, @course.lectures.first)
     end
   end
 end

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,3 +1,0 @@
-<h1>Courses#show</h1>
-<p>Find me in app/views/courses/show.html.erb</p>
-


### PR DESCRIPTION
Going to courses/1 (for example), will, instead of showing an empty rails-generated courses#show template page, it will go to the lecture show page for the first lecture in the course. 