### PR TITLE
The lecture description now appears as its own section below the video

### DIFF
--- a/app/views/lectures/_lecture.html.erb
+++ b/app/views/lectures/_lecture.html.erb
@@ -15,7 +15,6 @@
           <hr>
         </header>
         <section>
-          <%= @lecture.description %>
           <%= cl_video_tag(@lecture.video.key,
             :controls => true,
             :transformation => [
@@ -24,7 +23,12 @@
             :fallback_content => "Your browser does not support HTML5 video tags." )
           %>
         </section>
-        <section class="w-75 mt-5">
+        <section class="mt-4">
+        <h2>Lecture Description</h2>
+        <hr>
+        <p><%= @lecture.description %></p>
+        </section>
+        <section class="w-75 mt-4">
           <h2>Resources</h2>
           <hr>
           <% if @lecture.resources.count == 0 %>

--- a/app/views/lectures/_new_lecture_form.html.erb
+++ b/app/views/lectures/_new_lecture_form.html.erb
@@ -1,9 +1,9 @@
 <%= simple_form_for [@course, @lecture] do |form| %>
     <h2> Lecture Information </h2>
     <%= form.input :title, label: "New Lecture Title" %>
-    <p>Lecture Description: </p>
-    <%= form.rich_text_area :description, label: "Lecture Description" %>
     <%= form.input :video, as: :file, input_html: {accept: "video/*"}, label: "Lecture Video"%>
+    <h2>Lecture Description</h2>
+    <%= form.rich_text_area :description, label: "Lecture Description" %>
     <%= form.input :resources, as: :file, :input_html => { :multiple => true }, label: "Lecture Resources" %>
 
     <h2> Exercise Information </h2>


### PR DESCRIPTION
### Before (kinda problematic for long descriptions)

![image](https://user-images.githubusercontent.com/15717925/100904341-d6f8eb00-34be-11eb-88b9-e1dca7210f88.png)

### After: 

![image](https://user-images.githubusercontent.com/15717925/100904298-ca749280-34be-11eb-8ae3-e8388a234597.png)
