### PR TITLE
The exercise tab now consumes the page vertically

### DIFF
--- a/app/assets/stylesheets/pages/_lecture-show.scss
+++ b/app/assets/stylesheets/pages/_lecture-show.scss
@@ -8,7 +8,8 @@
   // flex-grow: 2;
   width: 75%;
   position: relative;	
-  left: 25%;	
+  left: 25%;
+  height: 100vh;
 }
 
 .lecture-show-content-tab {


### PR DESCRIPTION
### After:

![image](https://user-images.githubusercontent.com/15717925/100923835-b4270080-34d7-11eb-8572-efa7902f60aa.png)

### Before (notice how the grey background stops short): 

![image](https://user-images.githubusercontent.com/15717925/100923904-cd2fb180-34d7-11eb-9543-421126a40624.png)
