### PR TITLE
fixed navbar and home html

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -16,9 +16,9 @@
 </div>
 
 
-<h1 class="text-center pb-4 pt-5">How We're Different</h1>
+<h1 class="text-center pb-4 pt-5" id="about-scroll">How We're Different</h1>
 
-  <div class="different" id="about-scroll">
+  <div class="different">
     <div class="card-different">
       <img src="<%= image_path "cloud2.png"  %>" width="100px" alt="symbol" class="img-circle">
       <h2 class="mt-3">Creativity first</h2>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -17,7 +17,7 @@
     <% else %>
     <ul class="primary-nav">
       <li class="nav-item-active">
-        <%= link_to "Home", root_path, class: "nav-link" %>
+        <%= link_to "Home", root_path, method: :get, class: "nav-link" %>
       </li>
     </ul>
   <% end %>


### PR DESCRIPTION
If you click the "home" nav link it would kill the javascript text scramble effect. I have fixed this.
Also if you click "courses" nav link on the navbar, it'll scroll to the appropriate section header.